### PR TITLE
🔒 Secure MySQL connection by enabling SSL by default

### DIFF
--- a/src/main/java/com/aureleconomy/database/DatabaseManager.java
+++ b/src/main/java/com/aureleconomy/database/DatabaseManager.java
@@ -90,8 +90,9 @@ public class DatabaseManager {
         String database = config.getString("database.mysql.database", "aurelium");
         String username = config.getString("database.mysql.username", "root");
         String password = config.getString("database.mysql.password", "");
+        boolean useSSL = config.getBoolean("database.mysql.use-ssl", true);
 
-        String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?autoReconnect=true&useSSL=false";
+        String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?autoReconnect=true&useSSL=" + useSSL;
         connection = DriverManager.getConnection(url, username, password);
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,7 @@ database:
     database: "aurelium"
     username: "root"
     password: "password"
+    use-ssl: true
 
 # --- Economy ---
 economy:


### PR DESCRIPTION
### 🎯 What:
The MySQL database connection was previously hardcoded to use `useSSL=false` in the JDBC URL, which disabled encryption for all database traffic.

### ⚠️ Risk:
Disabling SSL for database connections exposes sensitive information, including database credentials and all stored data (player balances, auction listings, etc.), to potential interception via man-in-the-middle (MITM) attacks.

### 🛡️ Solution:
- Modified `DatabaseManager.java` to read the SSL preference from the configuration.
- Enabled SSL by default (`useSSL=true`) in the JDBC connection string.
- Added a `use-ssl` boolean option to the `mysql` section in `config.yml` to allow for flexibility in environments where SSL might not be available (though it is strongly discouraged for production).

---
*PR created automatically by Jules for task [10037143416680619318](https://jules.google.com/task/10037143416680619318) started by @APPLEPIE6969*