### PR TITLE
⚡ Optimize offline earnings cleanup in JoinListener

### DIFF
--- a/src/main/java/com/aureleconomy/listeners/JoinListener.java
+++ b/src/main/java/com/aureleconomy/listeners/JoinListener.java
@@ -35,7 +35,6 @@ public class JoinListener implements Listener {
                 boolean hasEarnings = false;
                 while (rs.next()) {
                     hasEarnings = true;
-                    int id = rs.getInt("id");
                     BigDecimal amount = rs.getBigDecimal("amount");
                     String itemDisplay = rs.getString("item_display");
 
@@ -46,11 +45,12 @@ public class JoinListener implements Listener {
                             .append(Component.text(itemDisplay, NamedTextColor.AQUA))
                             .append(Component.text(" while you were offline.", NamedTextColor.GREEN)));
 
-                    // Delete record
-                    deleteRecord(id);
                 }
 
                 if (hasEarnings) {
+                    // Delete all processed records for this UUID
+                    deleteAllRecordsForUUID(uuid);
+
                     event.getPlayer().sendMessage(
                             Component.text("--------------------------------------------------", NamedTextColor.GOLD));
                 }
@@ -61,13 +61,13 @@ public class JoinListener implements Listener {
         });
     }
 
-    private void deleteRecord(int id) {
+    private void deleteAllRecordsForUUID(UUID uuid) {
         try (PreparedStatement ps = plugin.getDatabaseManager().getConnection()
-                .prepareStatement("DELETE FROM offline_earnings WHERE id = ?")) {
-            ps.setInt(1, id);
+                .prepareStatement("DELETE FROM offline_earnings WHERE uuid = ?")) {
+            ps.setString(1, uuid.toString());
             ps.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            plugin.getComponentLogger().error("Database error while deleting offline earnings for " + uuid, e);
         }
     }
 }


### PR DESCRIPTION
💡 **What:** Replaced individual `DELETE` queries for each offline earning record with a single bulk `DELETE` query for the player's `UUID` after all earnings have been processed and displayed.

🎯 **Why:** The previous implementation had an N+1 query problem, where a separate database request was made for every single earning record in the result set. This could lead to performance issues when a player joins after a long period of inactivity with many accumulated sales.

📊 **Measured Improvement:** While a direct benchmark in this environment was impractical due to network timeouts and environmental constraints, this is a standard N+1 query optimization. Reducing $N+1$ database operations to 2 (one `SELECT`, one `DELETE`) significantly reduces I/O overhead and database contention, especially for players with many offline earnings.

---
*PR created automatically by Jules for task [18047320461958201232](https://jules.google.com/task/18047320461958201232) started by @APPLEPIE6969*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized offline earnings data processing for improved efficiency
  * Enhanced error logging and diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->