### PR TITLE
⚡ Performance: Cache offline player names in GUIs

### DIFF
--- a/src/main/java/com/aureleconomy/gui/AuctionGUI.java
+++ b/src/main/java/com/aureleconomy/gui/AuctionGUI.java
@@ -135,7 +135,7 @@ public class AuctionGUI extends GUIHolder {
                 break;
 
             ItemStack display = ai.getItem().clone();
-            String sellerName = Bukkit.getOfflinePlayer(ai.getSeller()).getName();
+            String sellerName = com.aureleconomy.utils.PlayerNameCache.getName(ai.getSeller());
             String priceFormatted = plugin.getEconomyManager().getFormattedWithSymbol(ai.getPrice(), ai.getCurrency());
             String priceLine = (ai.isBin() ? "Buy It Now: " : "Current Bid: ") + priceFormatted;
             String timeLeft = formatTime(ai.getExpiration() - System.currentTimeMillis());

--- a/src/main/java/com/aureleconomy/gui/OffersGUI.java
+++ b/src/main/java/com/aureleconomy/gui/OffersGUI.java
@@ -54,7 +54,7 @@ public class OffersGUI extends GUIHolder {
                     if (ai == null) continue;
 
                     ItemStack display = ai.getItem().clone();
-                    String bidderName = Bukkit.getOfflinePlayer(offer.getBidder()).getName();
+                    String bidderName = com.aureleconomy.utils.PlayerNameCache.getName(offer.getBidder());
                     String amountFormatted = plugin.getEconomyManager().format(offer.getAmount(), ai.getCurrency());
 
                     display.editMeta(meta -> {

--- a/src/main/java/com/aureleconomy/gui/OrdersGUI.java
+++ b/src/main/java/com/aureleconomy/gui/OrdersGUI.java
@@ -69,9 +69,9 @@ public class OrdersGUI extends GUIHolder {
 
             BuyOrder order = filtered.get(startIdx + i);
             String displayMat = order.getMaterial().name().replace("_", " ").toLowerCase();
-            String playerName = Bukkit.getOfflinePlayer(order.getBuyerUuid()).getName();
-            if (playerName == null)
-                playerName = "Unknown";
+            String playerName = com.aureleconomy.utils.PlayerNameCache.getName(order.getBuyerUuid());
+
+
 
             inventory.setItem(i, new ItemBuilder(order.getMaterial())
                     .name(Component.text("Buying: " + displayMat, NamedTextColor.GOLD, TextDecoration.BOLD))

--- a/src/main/java/com/aureleconomy/utils/PlayerNameCache.java
+++ b/src/main/java/com/aureleconomy/utils/PlayerNameCache.java
@@ -1,0 +1,20 @@
+package com.aureleconomy.utils;
+
+import org.bukkit.Bukkit;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PlayerNameCache {
+    private static final Map<UUID, String> cache = new ConcurrentHashMap<>();
+
+    public static String getName(UUID uuid) {
+        if (uuid == null) return "Unknown";
+
+        return cache.computeIfAbsent(uuid, k -> {
+            String name = Bukkit.getOfflinePlayer(k).getName();
+            return name != null ? name : "Unknown";
+        });
+    }
+}


### PR DESCRIPTION
* **What:** Created a `PlayerNameCache` utility class using a `ConcurrentHashMap` to cache the string result of `Bukkit.getOfflinePlayer(uuid).getName()`. Applied this cache to the rendering logic in `OrdersGUI`, `AuctionGUI`, and `OffersGUI`.
* **Why:** Calling `Bukkit.getOfflinePlayer` on the main server thread forces synchronous disk and/or network I/O to read player data. Doing this inside a loop for GUI item rendering causes substantial server lag and TPS drops.
* **Measured Improvement:** While a direct programmatic benchmark against `Bukkit` APIs requires a running Minecraft server environment, caching UUID-to-String lookups replaces milliseconds-long I/O operations with nanosecond-fast HashMap accesses, improving the `setupItems` method execution time by orders of magnitude for large, populated GUIs.

---
*PR created automatically by Jules for task [17776848794263074111](https://jules.google.com/task/17776848794263074111) started by @APPLEPIE6969*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of player name lookups across auction, offers, and orders interfaces through optimized caching mechanisms. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->