### PR TITLE
Fix NPE: /eco and /bal crash on non-existent offline players

### DIFF
--- a/src/main/java/com/aureleconomy/commands/EconomyCommand.java
+++ b/src/main/java/com/aureleconomy/commands/EconomyCommand.java
@@ -20,290 +20,305 @@ import org.jetbrains.annotations.Nullable;
 
 public class EconomyCommand implements CommandExecutor, TabCompleter {
 
-    private final AurelEconomy plugin;
-    private final MiniMessage mm = MiniMessage.miniMessage();
+ private final AurelEconomy plugin;
+ private final MiniMessage mm = MiniMessage.miniMessage();
 
-    public EconomyCommand(AurelEconomy plugin) {
-        this.plugin = plugin;
-    }
+ public EconomyCommand(AurelEconomy plugin) {
+ this.plugin = plugin;
+ }
 
-    private boolean isValidCurrency(String currency) {
-        return plugin.getConfig().getConfigurationSection("economy.currencies").contains(currency);
-    }
+ private boolean isValidCurrency(String currency) {
+ return plugin.getConfig().getConfigurationSection("economy.currencies").contains(currency);
+ }
 
-    @Override
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
-            @NotNull String[] args) {
-        // /bal [player] [currency]
-        if (label.equalsIgnoreCase("bal") || label.equalsIgnoreCase("balance") || label.equalsIgnoreCase("money")) {
-            handleBalance(sender, args);
-            return true;
-        }
+ @Override
+ public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
+ @NotNull String[] args) {
+ if (label.equalsIgnoreCase("bal") || label.equalsIgnoreCase("balance") || label.equalsIgnoreCase("money")) {
+ handleBalance(sender, args);
+ return true;
+ }
 
-        // /pay <player> <amount> [currency]
-        if (label.equalsIgnoreCase("pay")) {
-            handlePay(sender, args);
-            return true;
-        }
+ if (label.equalsIgnoreCase("pay")) {
+ handlePay(sender, args);
+ return true;
+ }
 
-        // /eco <give|take|set> <player> <amount> [currency]
-        if (label.equalsIgnoreCase("eco")) {
-            handleEco(sender, args);
-            return true;
-        }
+ if (label.equalsIgnoreCase("eco")) {
+ handleEco(sender, args);
+ return true;
+ }
 
-        return false;
-    }
+ return false;
+ }
 
-    private void handleBalance(CommandSender sender, String[] args) {
-        if (!sender.hasPermission("aureleconomy.bal")) {
-            sender.sendMessage(Component.text("No permission.", NamedTextColor.RED));
-            return;
-        }
+ private void handleBalance(CommandSender sender, String[] args) {
+ if (!sender.hasPermission("aureleconomy.bal")) {
+ sender.sendMessage(Component.text("No permission.", NamedTextColor.RED));
+ return;
+ }
 
-        String targetName;
-        String currencyParam = null;
+ String targetName;
+ String currencyParam = null;
 
-        if (args.length == 0) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage(Component.text("Console must specify a player."));
-                return;
-            }
-            targetName = sender.getName();
-        } else if (args.length == 1) {
-            if (isValidCurrency(args[0])) {
-                if (!(sender instanceof Player)) {
-                    sender.sendMessage(Component.text("Console must specify a player."));
-                    return;
-                }
-                targetName = sender.getName();
-                currencyParam = args[0];
-            } else {
-                targetName = args[0];
-            }
-        } else {
-            targetName = args[0];
-            currencyParam = args[1];
-        }
+ if (args.length == 0) {
+ if (!(sender instanceof Player)) {
+ sender.sendMessage(Component.text("Console must specify a player."));
+ return;
+ }
+ targetName = sender.getName();
+ } else if (args.length == 1) {
+ if (isValidCurrency(args[0])) {
+ if (!(sender instanceof Player)) {
+ sender.sendMessage(Component.text("Console must specify a player."));
+ return;
+ }
+ targetName = sender.getName();
+ currencyParam = args[0];
+ } else {
+ targetName = args[0];
+ }
+ } else {
+ targetName = args[0];
+ currencyParam = args[1];
+ }
 
-        final String finalCurrency = currencyParam != null ? currencyParam
-                : plugin.getEconomyManager().getDefaultCurrency();
+ final String finalCurrency = currencyParam != null ? currencyParam
+ : plugin.getEconomyManager().getDefaultCurrency();
 
-        sender.sendMessage(Component.text("Checking balance...", NamedTextColor.GRAY));
+ sender.sendMessage(Component.text("Checking balance...", NamedTextColor.GRAY));
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            OfflinePlayer target = Bukkit.getOfflinePlayer(targetName);
-            BigDecimal bal = plugin.getEconomyManager().getBalance(target, finalCurrency);
-            String prefix = plugin.getConfig().getString("prefix", "<gold>[AurelEconomy] <gray>");
+ Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+ OfflinePlayer target = Bukkit.getOfflinePlayer(targetName);
+ if (target.getUniqueId() == null) {
+ Bukkit.getScheduler().runTask(plugin, () ->
+ sender.sendMessage(Component.text("Player not found: " + targetName, NamedTextColor.RED)));
+ return;
+ }
+ BigDecimal bal = plugin.getEconomyManager().getBalance(target, finalCurrency);
+ String prefix = plugin.getConfig().getString("prefix", "<gold>[AurelEconomy] <gray>");
 
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                String formatted = plugin.getEconomyManager().format(bal, finalCurrency);
-                String symbol = plugin.getEconomyManager().getCurrencySymbol(finalCurrency);
-                if (sender instanceof Player p && target.getUniqueId().equals(p.getUniqueId())) {
-                    String msg = plugin.getConfig().getString("economy.balance",
-                            "Balance (%currency%): %amount%%symbol%");
-                    sender.sendMessage(mm.deserialize(prefix + msg
-                            .replace("%currency%", finalCurrency)
-                            .replace("%amount%", formatted)
-                            .replace("%symbol%", symbol)));
-                } else {
-                    String msg = plugin.getConfig().getString("economy.balance-other",
-                            "Balance of %player% (%currency%): %amount%%symbol%");
-                    sender.sendMessage(mm.deserialize(prefix + msg
-                            .replace("%player%", target.getName() != null ? target.getName() : targetName)
-                            .replace("%currency%", finalCurrency)
-                            .replace("%amount%", formatted)
-                            .replace("%symbol%", symbol)));
-                }
-            });
-        });
-    }
+ Bukkit.getScheduler().runTask(plugin, () -> {
+ String formatted = plugin.getEconomyManager().format(bal, finalCurrency);
+ String symbol = plugin.getEconomyManager().getCurrencySymbol(finalCurrency);
+ if (sender instanceof Player p && target.getUniqueId().equals(p.getUniqueId())) {
+ String msg = plugin.getConfig().getString("economy.balance",
+ "Balance (%currency%): %amount%%symbol%");
+ sender.sendMessage(mm.deserialize(prefix + msg
+ .replace("%currency%", finalCurrency)
+ .replace("%amount%", formatted)
+ .replace("%symbol%", symbol)));
+ } else {
+ String msg = plugin.getConfig().getString("economy.balance-other",
+ "Balance of %player% (%currency%): %amount%%symbol%");
+ sender.sendMessage(mm.deserialize(prefix + msg
+ .replace("%player%", target.getName() != null ? target.getName() : targetName)
+ .replace("%currency%", finalCurrency)
+ .replace("%amount%", formatted)
+ .replace("%symbol%", symbol)));
+ }
+ });
+ });
+ }
 
-    private void handlePay(CommandSender sender, String[] args) {
-        if (!(sender instanceof Player player)) {
-            sender.sendMessage(Component.text("Only players can pay."));
-            return;
-        }
+ private void handlePay(CommandSender sender, String[] args) {
+ if (!(sender instanceof Player player)) {
+ sender.sendMessage(Component.text("Only players can pay."));
+ return;
+ }
 
-        if (!player.hasPermission("aureleconomy.pay")) {
-            player.sendMessage(Component.text("You do not have permission to pay other players.", NamedTextColor.RED));
-            return;
-        }
+ if (!player.hasPermission("aureleconomy.pay")) {
+ player.sendMessage(Component.text("You do not have permission to pay other players.", NamedTextColor.RED));
+ return;
+ }
 
-        if (args.length < 2) {
-            player.sendMessage(Component.text("Usage: /pay <player> <amount> [currency]"));
-            return;
-        }
+ if (args.length < 2) {
+ player.sendMessage(Component.text("Usage: /pay <player> <amount> [currency]"));
+ return;
+ }
 
-        BigDecimal amount;
-        try {
-            amount = new BigDecimal(args[1]);
-        } catch (NumberFormatException e) {
-            player.sendMessage(Component.text("Invalid amount."));
-            return;
-        }
+ BigDecimal amount;
+ try {
+ amount = new BigDecimal(args[1]);
+ } catch (NumberFormatException e) {
+ player.sendMessage(Component.text("Invalid amount."));
+ return;
+ }
 
-        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
-            player.sendMessage(Component.text("Amount must be positive.", NamedTextColor.RED));
-            return;
-        }
+ if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+ player.sendMessage(Component.text("Amount must be positive.", NamedTextColor.RED));
+ return;
+ }
 
-        String currency = (args.length >= 3) ? args[2] : plugin.getEconomyManager().getDefaultCurrency();
-        if (!isValidCurrency(currency)) {
-            player.sendMessage(Component.text("Invalid currency: " + currency, NamedTextColor.RED));
-            return;
-        }
+ String currency = (args.length >= 3) ? args[2] : plugin.getEconomyManager().getDefaultCurrency();
+ if (!isValidCurrency(currency)) {
+ player.sendMessage(Component.text("Invalid currency: " + currency, NamedTextColor.RED));
+ return;
+ }
 
-        String targetName = args[0];
-        player.sendMessage(Component.text("Processing payment...", NamedTextColor.GRAY));
+ String targetName = args[0];
+ player.sendMessage(Component.text("Processing payment...", NamedTextColor.GRAY));
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            OfflinePlayer target = Bukkit.getOfflinePlayer(targetName);
+ Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+ OfflinePlayer target = Bukkit.getOfflinePlayer(targetName);
 
-            if (target.getUniqueId().equals(player.getUniqueId())) {
-                Bukkit.getScheduler().runTask(plugin,
-                        () -> player.sendMessage(Component.text("You cannot pay yourself.", NamedTextColor.RED)));
-                return;
-            }
+ if (target.getUniqueId() == null) {
+ Bukkit.getScheduler().runTask(plugin,
+ () -> player.sendMessage(Component.text("Player not found: " + targetName, NamedTextColor.RED)));
+ return;
+ }
 
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                if (plugin.getEconomyManager().has(player, amount, currency)) {
-                    plugin.getEconomyManager().withdraw(player, amount, currency);
-                    plugin.getEconomyManager().deposit(target, amount, currency);
-                    String formatted = plugin.getEconomyManager().format(amount, currency);
-                    String symbol = plugin.getEconomyManager().getCurrencySymbol(currency);
+ if (target.getUniqueId().equals(player.getUniqueId())) {
+ Bukkit.getScheduler().runTask(plugin,
+ () -> player.sendMessage(Component.text("You cannot pay yourself.", NamedTextColor.RED)));
+ return;
+ }
 
-                    String payMsg = plugin.getConfig().getString("economy.paid",
-                            "<green>You paid <white>%player% <yellow>%amount%%symbol%")
-                            .replace("%player%", target.getName() != null ? target.getName() : targetName)
-                            .replace("%amount%", formatted)
-                            .replace("%symbol%", symbol)
-                            .replace("%currency%", currency);
-                    player.sendMessage(mm.deserialize(payMsg));
+ Bukkit.getScheduler().runTask(plugin, () -> {
+ if (plugin.getEconomyManager().has(player, amount, currency)) {
+ plugin.getEconomyManager().withdraw(player, amount, currency);
+ plugin.getEconomyManager().deposit(target, amount, currency);
+ String formatted = plugin.getEconomyManager().format(amount, currency);
+ String symbol = plugin.getEconomyManager().getCurrencySymbol(currency);
 
-                    if (target.isOnline()) {
-                        Player op = target.getPlayer();
-                        if (op != null) {
-                            String recvMsg = plugin.getConfig().getString("economy.received",
-                                    "<green>You received <yellow>%amount%%symbol% <green>from <white>%player%")
-                                    .replace("%player%", player.getName())
-                                    .replace("%amount%", formatted)
-                                    .replace("%symbol%", symbol)
-                                    .replace("%currency%", currency);
-                            op.sendMessage(mm.deserialize(recvMsg));
-                        }
-                    }
-                } else {
-                    player.sendMessage(Component.text("Insufficient funds.", NamedTextColor.RED));
-                }
-            });
-        });
-    }
+ String payMsg = plugin.getConfig().getString("economy.paid",
+ "<green>You paid <white>%player% <yellow>%amount%%symbol%")
+ .replace("%player%", target.getName() != null ? target.getName() : targetName)
+ .replace("%amount%", formatted)
+ .replace("%symbol%", symbol)
+ .replace("%currency%", currency);
+ player.sendMessage(mm.deserialize(payMsg));
 
-    private void handleEco(CommandSender sender, String[] args) {
-        if (!sender.hasPermission("aureleconomy.admin")) {
-            sender.sendMessage(Component.text("No permission."));
-            return;
-        }
+ if (target.isOnline()) {
+ Player op = target.getPlayer();
+ if (op != null) {
+ String recvMsg = plugin.getConfig().getString("economy.received",
+ "<green>You received <yellow>%amount%%symbol% <green>from <white>%player%")
+ .replace("%player%", player.getName())
+ .replace("%amount%", formatted)
+ .replace("%symbol%", symbol)
+ .replace("%currency%", currency);
+ op.sendMessage(mm.deserialize(recvMsg));
+ }
+ }
+ } else {
+ player.sendMessage(Component.text("Insufficient funds.", NamedTextColor.RED));
+ }
+ });
+ });
+ }
 
-        if (args.length < 3) { // Requires give|take|set, player, amount
-            sender.sendMessage(Component.text("Usage: /eco <give|take|set> <player> <amount> [currency]"));
-            return;
-        }
+ private void handleEco(CommandSender sender, String[] args) {
+ if (!sender.hasPermission("aureleconomy.admin")) {
+ sender.sendMessage(Component.text("No permission."));
+ return;
+ }
 
-        String action = args[0].toLowerCase();
-        OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
-        BigDecimal amount;
+ if (args.length < 3) {
+ sender.sendMessage(Component.text("Usage: /eco <give|take|set> <player> <amount> [currency]"));
+ return;
+ }
 
-        try {
-            amount = new BigDecimal(args[2]);
-            if (amount.compareTo(BigDecimal.ZERO) <= 0) {
-                sender.sendMessage(Component.text("Amount must be positive.", NamedTextColor.RED));
-                return;
-            }
-        } catch (NumberFormatException e) {
-            sender.sendMessage(Component.text("Invalid amount."));
-            return;
-        }
+ String action = args[0].toLowerCase();
+ OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
 
-        String currency = args.length >= 4 ? args[3] : plugin.getEconomyManager().getDefaultCurrency();
-        if (!isValidCurrency(currency)) {
-            sender.sendMessage(Component.text("Invalid currency: " + currency));
-            return;
-        }
+ if (target.getUniqueId() == null) {
+ sender.sendMessage(Component.text("Player not found: " + args[1], NamedTextColor.RED));
+ return;
+ }
 
-        String prefix = plugin.getConfig().getString("prefix", "[AurelEconomy] ");
+ BigDecimal amount;
 
-        switch (action) {
-            case "give":
-                plugin.getEconomyManager().deposit(target, amount, currency);
-                sender.sendMessage(mm.deserialize(prefix +
-                        plugin.getConfig().getString("economy.admin-give", "Gave %player% %amount% (%currency%)")
-                                .replace("%player%", target.getName() != null ? target.getName() : "You")
-                                .replace("%currency%", currency)
-                                .replace("%amount%", plugin.getEconomyManager().format(amount, currency))
-                                .replace("%symbol%", plugin.getEconomyManager().getCurrencySymbol(currency))));
-                break;
-            case "take":
-                plugin.getEconomyManager().withdraw(target, amount, currency);
-                sender.sendMessage(mm.deserialize(prefix +
-                        plugin.getConfig().getString("economy.admin-take", "Took %amount% (%currency%) from %player%")
-                                .replace("%player%", target.getName() != null ? target.getName() : "You")
-                                .replace("%currency%", currency)
-                                .replace("%amount%", plugin.getEconomyManager().format(amount, currency))
-                                .replace("%symbol%", plugin.getEconomyManager().getCurrencySymbol(currency))));
-                break;
-            case "set":
-                plugin.getEconomyManager().setBalance(target, amount, currency);
-                sender.sendMessage(mm.deserialize(prefix +
-                        plugin.getConfig().getString("economy.admin-set", "Set balance of %player% to %amount% (%currency%)")
-                                .replace("%player%", target.getName() != null ? target.getName() : "You")
-                                .replace("%currency%", currency)
-                                .replace("%amount%", plugin.getEconomyManager().format(amount, currency))
-                                .replace("%symbol%", plugin.getEconomyManager().getCurrencySymbol(currency))));
-                break;
-            default:
-                sender.sendMessage(Component.text("Unknown action: " + action));
-        }
-    }
+ try {
+ amount = new BigDecimal(args[2]);
+ if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+ sender.sendMessage(Component.text("Amount must be positive.", NamedTextColor.RED));
+ return;
+ }
+ } catch (NumberFormatException e) {
+ sender.sendMessage(Component.text("Invalid amount."));
+ return;
+ }
 
-    @Override
-    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
-            @NotNull String label, @NotNull String[] args) {
-        List<String> currencies = new ArrayList<>(
-                plugin.getConfig().getConfigurationSection("economy.currencies").getKeys(false));
+ String currency = args.length >= 4 ? args[3] : plugin.getEconomyManager().getDefaultCurrency();
+ if (!isValidCurrency(currency)) {
+ sender.sendMessage(Component.text("Invalid currency: " + currency));
+ return;
+ }
 
-        if (label.equalsIgnoreCase("bal") || label.equalsIgnoreCase("balance") || label.equalsIgnoreCase("money")) {
-            if (args.length == 1) {
-                List<String> suggestions = new ArrayList<>(currencies);
-                for (Player p : Bukkit.getOnlinePlayers()) {
-                    suggestions.add(p.getName());
-                }
-                return suggestions;
-            }
-            if (args.length == 2)
-                return currencies; // player, [currency]
-        }
+ String prefix = plugin.getConfig().getString("prefix", "[AurelEconomy] ");
+ String displayName = target.getName() != null ? target.getName() : args[1];
 
-        if (label.equalsIgnoreCase("pay")) {
-            if (args.length == 1)
-                return null; // online players
-            if (args.length == 2)
-                return Collections.emptyList(); // amount
-            if (args.length == 3)
-                return currencies; // [currency]
-        }
+ switch (action) {
+ case "give":
+ plugin.getEconomyManager().deposit(target, amount, currency);
+ sender.sendMessage(mm.deserialize(prefix +
+ plugin.getConfig().getString("economy.admin-give", "Gave %player% %amount% (%currency%)")
+ .replace("%player%", displayName)
+ .replace("%currency%", currency)
+ .replace("%amount%", plugin.getEconomyManager().format(amount, currency))
+ .replace("%symbol%", plugin.getEconomyManager().getCurrencySymbol(currency))));
+ break;
+ case "take":
+ plugin.getEconomyManager().withdraw(target, amount, currency);
+ sender.sendMessage(mm.deserialize(prefix +
+ plugin.getConfig().getString("economy.admin-take", "Took %amount% (%currency%) from %player%")
+ .replace("%player%", displayName)
+ .replace("%currency%", currency)
+ .replace("%amount%", plugin.getEconomyManager().format(amount, currency))
+ .replace("%symbol%", plugin.getEconomyManager().getCurrencySymbol(currency))));
+ break;
+ case "set":
+ plugin.getEconomyManager().setBalance(target, amount, currency);
+ sender.sendMessage(mm.deserialize(prefix +
+ plugin.getConfig().getString("economy.admin-set", "Set balance of %player% to %amount% (%currency%)")
+ .replace("%player%", displayName)
+ .replace("%currency%", currency)
+ .replace("%amount%", plugin.getEconomyManager().format(amount, currency))
+ .replace("%symbol%", plugin.getEconomyManager().getCurrencySymbol(currency))));
+ break;
+ default:
+ sender.sendMessage(Component.text("Unknown action: " + action));
+ }
+ }
 
-        if (label.equalsIgnoreCase("eco")) {
-            if (args.length == 1)
-                return List.of("give", "take", "set");
-            if (args.length == 2)
-                return null; // offline players
-            if (args.length == 3)
-                return Collections.emptyList(); // amount
-            if (args.length == 4)
-                return currencies; // [currency]
-        }
-        return Collections.emptyList();
-    }
+ @Override
+ public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
+ @NotNull String label, @NotNull String[] args) {
+ List<String> currencies = new ArrayList<>(
+ plugin.getConfig().getConfigurationSection("economy.currencies").getKeys(false));
+
+ if (label.equalsIgnoreCase("bal") || label.equalsIgnoreCase("balance") || label.equalsIgnoreCase("money")) {
+ if (args.length == 1) {
+ List<String> suggestions = new ArrayList<>(currencies);
+ for (Player p : Bukkit.getOnlinePlayers()) {
+ suggestions.add(p.getName());
+ }
+ return suggestions;
+ }
+ if (args.length == 2)
+ return currencies;
+ }
+
+ if (label.equalsIgnoreCase("pay")) {
+ if (args.length == 1)
+ return null;
+ if (args.length == 2)
+ return Collections.emptyList();
+ if (args.length == 3)
+ return currencies;
+ }
+
+ if (label.equalsIgnoreCase("eco")) {
+ if (args.length == 1)
+ return List.of("give", "take", "set");
+ if (args.length == 2)
+ return null;
+ if (args.length == 3)
+ return Collections.emptyList();
+ if (args.length == 4)
+ return currencies;
+ }
+ return Collections.emptyList();
+ }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,76 +4,80 @@ main: com.aureleconomy.AurelEconomy
 api-version: '26.1'
 description: Economy plugin with market, auction house, and web dashboard.
 authors:
- - APPLEPIE6969
+  - APPLEPIE6969
 softdepend: [Vault]
 
 commands:
- bal:
- description: Check your balance
- usage: /bal [player]
- permission: aureleconomy.bal
- aliases: [balance, money]
- pay:
- description: Send money to someone
- usage: /pay <player> <amount>
- permission: aureleconomy.pay
- market:
- description: Browse the market
- usage: /market
- permission: aureleconomy.market
- ah:
- description: Auction house
- usage: /ah [sell|bid|collect]
- permission: aureleconomy.ah
- aliases: [auction]
- sell:
- description: Sell items from your inventory
- usage: /sell
- permission: aureleconomy.sell
- orders:
- description: Buy orders
- usage: /orders [create|fill|cancel|my|search|help]
- permission: aureleconomy.orders
- stocks:
- description: View item price trends
- usage: /stocks
- aliases: [stonks]
- eco:
- description: Admin money commands
- usage: /eco <give|take|set> [player] <amount>
- permission: aureleconomy.admin
- web:
- description: Open the web dashboard
- usage: /web
- permission: aureleconomy.web
+  bal:
+    description: Check your balance
+    usage: /bal [player]
+    permission: aureleconomy.bal
+    aliases:
+      - balance
+      - money
+  pay:
+    description: Send money to someone
+    usage: /pay <player> <amount>
+    permission: aureleconomy.pay
+  market:
+    description: Browse the market
+    usage: /market
+    permission: aureleconomy.market
+  ah:
+    description: Auction house
+    usage: /ah [sell|bid|collect]
+    permission: aureleconomy.ah
+    aliases:
+      - auction
+  sell:
+    description: Sell items from your inventory
+    usage: /sell
+    permission: aureleconomy.sell
+  orders:
+    description: Buy orders
+    usage: /orders [create|fill|cancel|my|search|help]
+    permission: aureleconomy.orders
+  stocks:
+    description: View item price trends
+    usage: /stocks
+    aliases:
+      - stonks
+  eco:
+    description: Admin money commands
+    usage: /eco <give|take|set> [player] <amount>
+    permission: aureleconomy.admin
+  web:
+    description: Open the web dashboard
+    usage: /web
+    permission: aureleconomy.web
 
 permissions:
- aureleconomy.admin:
- description: Admin commands
- aureleconomy.market:
- description: Use the market
- default: true
- aureleconomy.ah:
- description: Use the auction house
- default: true
- aureleconomy.bal:
- description: Check balance
- default: true
- aureleconomy.pay:
- description: Pay players
- default: true
- aureleconomy.sell:
- description: Use /sell
- default: true
- aureleconomy.orders:
- description: Use buy orders
- default: true
- aureleconomy.web:
- description: Use /web
- default: true
- aureleconomy.stocks:
- description: Use /stocks
- default: true
+  aureleconomy.admin:
+    description: Admin commands
+  aureleconomy.market:
+    description: Use the market
+    default: true
+  aureleconomy.ah:
+    description: Use the auction house
+    default: true
+  aureleconomy.bal:
+    description: Check balance
+    default: true
+  aureleconomy.pay:
+    description: Pay players
+    default: true
+  aureleconomy.sell:
+    description: Use /sell
+    default: true
+  aureleconomy.orders:
+    description: Use buy orders
+    default: true
+  aureleconomy.web:
+    description: Use /web
+    default: true
+  aureleconomy.stocks:
+    description: Use /stocks
+    default: true
 
 libraries:
- - org.xerial:sqlite-jdbc:3.45.3.0
+  - org.xerial:sqlite-jdbc:3.45.3.0


### PR DESCRIPTION
## Bug

`/eco give/take/set <player> <amount>` and `/bal <player>` throw `NullPointerException` when targeting players who have never joined the server.

`Bukkit.getOfflinePlayer(name)` returns an `OfflinePlayer` with a **null UUID** for unknown names. The `EconomyManager` then calls `uuid.toString()` unconditionally, causing an NPE that Paper surfaces as "An unexpected error occurred trying to execute that command".

## Fix

Added `target.getUniqueId() == null` guards in `EconomyCommand.java`:

- **`handleEco()`** — checks before any deposit/withdraw/setBalance call
- **`handleBalance()`** — checks in the async block before loading balance
- **`handlePay()`** — checks in the async block before processing payment

When a null UUID is detected, the sender gets a clear `"Player not found: <name>"` error message instead of a cryptic "unexpected error".

## Testing

- `smoke-test` ✅ — plugin loads, no exceptions
- `ingame-test` — should pass 25/25 RCON tests (commands targeting "TestPlayer" will now return "Player not found" instead of crashing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Error messages in economy commands now display with enhanced red color formatting to improve visibility and make error states more easily distinguishable from regular command feedback.

* **Chores**
  * Code formatting and configuration file restructuring have been applied for consistency and improved codebase maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/APPLEPIE6969/Aurelium/pull/20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->